### PR TITLE
Feature/m0 003 seed deterministico

### DIFF
--- a/BudgetPilot.Tests/Integration/HealthCheckTests.cs
+++ b/BudgetPilot.Tests/Integration/HealthCheckTests.cs
@@ -5,11 +5,11 @@ using Xunit;
 
 namespace BudgetPilot.Tests.Integration;
 
-public class HealthCheckTests : IClassFixture<WebApplicationFactory<Program>>
+public class HealthCheckTests : IClassFixture<TestWebApplicationFactory>
 {
     private readonly WebApplicationFactory<Program> _factory;
 
-    public HealthCheckTests(WebApplicationFactory<Program> factory)
+    public HealthCheckTests(TestWebApplicationFactory factory)
     {
         _factory = factory;
     }

--- a/BudgetPilot.Tests/Integration/TestWebApplicationFactory.cs
+++ b/BudgetPilot.Tests/Integration/TestWebApplicationFactory.cs
@@ -1,0 +1,54 @@
+using System.Collections.Generic;
+using System.Linq;
+using BudgetPilot.Web.Data;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Hosting;
+
+namespace BudgetPilot.Tests.Integration;
+
+public class TestWebApplicationFactory : WebApplicationFactory<Program>
+{
+    protected override IHost CreateHost(IHostBuilder builder)
+    {
+        builder.UseEnvironment("Test");
+
+        builder.ConfigureAppConfiguration((context, configBuilder) =>
+        {
+            var overrides = new Dictionary<string, string?>
+            {
+                ["Database:ApplyMigrations"] = "false",
+                ["Database:ApplySeed"] = "false"
+            };
+            configBuilder.AddInMemoryCollection(overrides);
+        });
+
+        builder.ConfigureServices(services =>
+        {
+            var descriptor = services.SingleOrDefault(d => d.ServiceType == typeof(DbContextOptions<ApplicationDbContext>));
+            if (descriptor != null)
+            {
+                services.Remove(descriptor);
+            }
+
+            services.AddDbContext<ApplicationDbContext>(options =>
+                options.UseInMemoryDatabase("BudgetPilotTests"));
+
+            services.AddHealthChecks()
+                .AddCheck("noop", () => HealthCheckResult.Healthy());
+        });
+
+        return base.CreateHost(builder);
+    }
+
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        // Intentionally left minimal; configuration is applied in CreateHost
+    }
+}
+
+

--- a/BudgetPilot.Web/Data/Seed/DatabaseSeeder.cs
+++ b/BudgetPilot.Web/Data/Seed/DatabaseSeeder.cs
@@ -1,0 +1,85 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using BudgetPilot.Web.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace BudgetPilot.Web.Data.Seed;
+
+public static class DatabaseSeeder
+{
+    public static async Task SeedAsync(ApplicationDbContext db)
+    {
+        // Seed Family
+        if (!await db.Families.AnyAsync(f => f.Id == SeedIds.DemoFamilyId))
+        {
+            db.Families.Add(new Family
+            {
+                Id = SeedIds.DemoFamilyId,
+                Name = "Demo Family",
+                Currency = "EUR",
+                Culture = "it-IT",
+            });
+        }
+
+        // Seed Categories with color and icon
+        if (!await db.Categories.IgnoreQueryFilters().AnyAsync(c => c.FamilyId == SeedIds.DemoFamilyId))
+        {
+            db.Categories.AddRange(
+                new Category
+                {
+                    Id = SeedIds.CategoryEssenzialiId,
+                    FamilyId = SeedIds.DemoFamilyId,
+                    Name = "Essenziali (50%)",
+                    Color = "#1f77b4",
+                    Icon = "home"
+                },
+                new Category
+                {
+                    Id = SeedIds.CategoryDesideriId,
+                    FamilyId = SeedIds.DemoFamilyId,
+                    Name = "Desideri (30%)",
+                    Color = "#ff7f0e",
+                    Icon = "gift"
+                },
+                new Category
+                {
+                    Id = SeedIds.CategoryRisparmiId,
+                    FamilyId = SeedIds.DemoFamilyId,
+                    Name = "Risparmi (20%)",
+                    Color = "#2ca02c",
+                    Icon = "piggy-bank"
+                }
+            );
+        }
+
+        // Seed Accounts
+        if (!await db.Accounts.IgnoreQueryFilters().AnyAsync(a => a.FamilyId == SeedIds.DemoFamilyId))
+        {
+            db.Accounts.AddRange(
+                new Account
+                {
+                    Id = SeedIds.AccountContoPrincipaleId,
+                    FamilyId = SeedIds.DemoFamilyId,
+                    Name = "Conto Principale"
+                },
+                new Account
+                {
+                    Id = SeedIds.AccountCartaId,
+                    FamilyId = SeedIds.DemoFamilyId,
+                    Name = "Carta"
+                },
+                new Account
+                {
+                    Id = SeedIds.AccountContantiId,
+                    FamilyId = SeedIds.DemoFamilyId,
+                    Name = "Contanti"
+                }
+            );
+        }
+
+        await db.SaveChangesAsync();
+    }
+}
+
+

--- a/BudgetPilot.Web/Data/Seed/SeedIds.cs
+++ b/BudgetPilot.Web/Data/Seed/SeedIds.cs
@@ -1,0 +1,21 @@
+using System;
+
+namespace BudgetPilot.Web.Data.Seed;
+
+public static class SeedIds
+{
+    // Family
+    public static readonly Guid DemoFamilyId = Guid.Parse("11111111-1111-1111-1111-111111111111");
+
+    // Accounts
+    public static readonly Guid AccountContoPrincipaleId = Guid.Parse("22222222-2222-2222-2222-222222222222");
+    public static readonly Guid AccountCartaId = Guid.Parse("33333333-3333-3333-3333-333333333333");
+    public static readonly Guid AccountContantiId = Guid.Parse("44444444-4444-4444-4444-444444444444");
+
+    // Categories (50/30/20)
+    public static readonly Guid CategoryEssenzialiId = Guid.Parse("55555555-5555-5555-5555-555555555555"); // 50
+    public static readonly Guid CategoryDesideriId = Guid.Parse("66666666-6666-6666-6666-666666666666");   // 30
+    public static readonly Guid CategoryRisparmiId = Guid.Parse("77777777-7777-7777-7777-777777777777");   // 20
+}
+
+

--- a/BudgetPilot.Web/Migrations/20250824094339_SeedMetadata.Designer.cs
+++ b/BudgetPilot.Web/Migrations/20250824094339_SeedMetadata.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using BudgetPilot.Web.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace BudgetPilot.Web.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250824094339_SeedMetadata")]
+    partial class SeedMetadata
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/BudgetPilot.Web/Migrations/20250824094339_SeedMetadata.cs
+++ b/BudgetPilot.Web/Migrations/20250824094339_SeedMetadata.cs
@@ -1,0 +1,68 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace BudgetPilot.Web.Migrations
+{
+    /// <inheritdoc />
+    public partial class SeedMetadata : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "currency",
+                schema: "core",
+                table: "families",
+                type: "text",
+                nullable: false,
+                defaultValue: "EUR");
+
+            migrationBuilder.AddColumn<string>(
+                name: "culture",
+                schema: "core",
+                table: "families",
+                type: "text",
+                nullable: false,
+                defaultValue: "it-IT");
+
+            migrationBuilder.AddColumn<string>(
+                name: "color",
+                schema: "core",
+                table: "categories",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "icon",
+                schema: "core",
+                table: "categories",
+                type: "text",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "currency",
+                schema: "core",
+                table: "families");
+
+            migrationBuilder.DropColumn(
+                name: "culture",
+                schema: "core",
+                table: "families");
+
+            migrationBuilder.DropColumn(
+                name: "color",
+                schema: "core",
+                table: "categories");
+
+            migrationBuilder.DropColumn(
+                name: "icon",
+                schema: "core",
+                table: "categories");
+        }
+    }
+}

--- a/BudgetPilot.Web/Migrations/20250824095503_DemoSeedData.Designer.cs
+++ b/BudgetPilot.Web/Migrations/20250824095503_DemoSeedData.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using BudgetPilot.Web.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace BudgetPilot.Web.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250824095503_DemoSeedData")]
+    partial class DemoSeedData
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/BudgetPilot.Web/Migrations/20250824095503_DemoSeedData.cs
+++ b/BudgetPilot.Web/Migrations/20250824095503_DemoSeedData.cs
@@ -1,0 +1,96 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace BudgetPilot.Web.Migrations
+{
+    /// <inheritdoc />
+    public partial class DemoSeedData : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            var now = new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+            migrationBuilder.InsertData(
+                schema: "core",
+                table: "families",
+                columns: new[] { "id", "name", "created_at", "created_by", "updated_at", "updated_by", "currency", "culture" },
+                values: new object[] { new Guid("11111111-1111-1111-1111-111111111111"), "Demo Family", now, null, null, null, "EUR", "it-IT" }
+            );
+
+            migrationBuilder.InsertData(
+                schema: "core",
+                table: "categories",
+                columns: new[] { "id", "name", "parent_id", "created_at", "created_by", "updated_at", "updated_by", "family_id", "color", "icon" },
+                values: new object[,]
+                {
+                    { new Guid("55555555-5555-5555-5555-555555555555"), "Essenziali (50%)", null, now, null, null, null, new Guid("11111111-1111-1111-1111-111111111111"), "#1f77b4", "home" },
+                    { new Guid("66666666-6666-6666-6666-666666666666"), "Desideri (30%)", null, now, null, null, null, new Guid("11111111-1111-1111-1111-111111111111"), "#ff7f0e", "gift" },
+                    { new Guid("77777777-7777-7777-7777-777777777777"), "Risparmi (20%)", null, now, null, null, null, new Guid("11111111-1111-1111-1111-111111111111"), "#2ca02c", "piggy-bank" }
+                }
+            );
+
+            migrationBuilder.InsertData(
+                schema: "core",
+                table: "accounts",
+                columns: new[] { "id", "name", "created_at", "created_by", "updated_at", "updated_by", "family_id" },
+                values: new object[,]
+                {
+                    { new Guid("22222222-2222-2222-2222-222222222222"), "Conto Principale", now, null, null, null, new Guid("11111111-1111-1111-1111-111111111111") },
+                    { new Guid("33333333-3333-3333-3333-333333333333"), "Carta", now, null, null, null, new Guid("11111111-1111-1111-1111-111111111111") },
+                    { new Guid("44444444-4444-4444-4444-444444444444"), "Contanti", now, null, null, null, new Guid("11111111-1111-1111-1111-111111111111") }
+                }
+            );
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DeleteData(
+                schema: "core",
+                table: "accounts",
+                keyColumn: "id",
+                keyValue: new Guid("22222222-2222-2222-2222-222222222222")
+            );
+            migrationBuilder.DeleteData(
+                schema: "core",
+                table: "accounts",
+                keyColumn: "id",
+                keyValue: new Guid("33333333-3333-3333-3333-333333333333")
+            );
+            migrationBuilder.DeleteData(
+                schema: "core",
+                table: "accounts",
+                keyColumn: "id",
+                keyValue: new Guid("44444444-4444-4444-4444-444444444444")
+            );
+
+            migrationBuilder.DeleteData(
+                schema: "core",
+                table: "categories",
+                keyColumn: "id",
+                keyValue: new Guid("55555555-5555-5555-5555-555555555555")
+            );
+            migrationBuilder.DeleteData(
+                schema: "core",
+                table: "categories",
+                keyColumn: "id",
+                keyValue: new Guid("66666666-6666-6666-6666-666666666666")
+            );
+            migrationBuilder.DeleteData(
+                schema: "core",
+                table: "categories",
+                keyColumn: "id",
+                keyValue: new Guid("77777777-7777-7777-7777-777777777777")
+            );
+
+            migrationBuilder.DeleteData(
+                schema: "core",
+                table: "families",
+                keyColumn: "id",
+                keyValue: new Guid("11111111-1111-1111-1111-111111111111")
+            );
+        }
+    }
+}

--- a/BudgetPilot.Web/Migrations/20250824100000_SeedDemoData.cs
+++ b/BudgetPilot.Web/Migrations/20250824100000_SeedDemoData.cs
@@ -1,0 +1,105 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace BudgetPilot.Web.Migrations
+{
+    /// <inheritdoc />
+    public partial class SeedDemoData : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            var now = new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+            // Family
+            migrationBuilder.InsertData(
+                schema: "core",
+                table: "families",
+                columns: new[] { "id", "name", "created_at", "created_by", "updated_at", "updated_by", "currency", "culture" },
+                values: new object[] { new Guid("11111111-1111-1111-1111-111111111111"), "Demo Family", now, null, null, null, "EUR", "it-IT" }
+            );
+
+            // Categories 50/30/20
+            migrationBuilder.InsertData(
+                schema: "core",
+                table: "categories",
+                columns: new[] { "id", "name", "parent_id", "created_at", "created_by", "updated_at", "updated_by", "family_id", "color", "icon" },
+                values: new object[,]
+                {
+                    { new Guid("55555555-5555-5555-5555-555555555555"), "Essenziali (50%)", null, now, null, null, null, new Guid("11111111-1111-1111-1111-111111111111"), "#1f77b4", "home" },
+                    { new Guid("66666666-6666-6666-6666-666666666666"), "Desideri (30%)", null, now, null, null, null, new Guid("11111111-1111-1111-1111-111111111111"), "#ff7f0e", "gift" },
+                    { new Guid("77777777-7777-7777-7777-777777777777"), "Risparmi (20%)", null, now, null, null, null, new Guid("11111111-1111-1111-1111-111111111111"), "#2ca02c", "piggy-bank" }
+                }
+            );
+
+            // Accounts
+            migrationBuilder.InsertData(
+                schema: "core",
+                table: "accounts",
+                columns: new[] { "id", "name", "created_at", "created_by", "updated_at", "updated_by", "family_id" },
+                values: new object[,]
+                {
+                    { new Guid("22222222-2222-2222-2222-222222222222"), "Conto Principale", now, null, null, null, new Guid("11111111-1111-1111-1111-111111111111") },
+                    { new Guid("33333333-3333-3333-3333-333333333333"), "Carta", now, null, null, null, new Guid("11111111-1111-1111-1111-111111111111") },
+                    { new Guid("44444444-4444-4444-4444-444444444444"), "Contanti", now, null, null, null, new Guid("11111111-1111-1111-1111-111111111111") }
+                }
+            );
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            // Accounts
+            migrationBuilder.DeleteData(
+                schema: "core",
+                table: "accounts",
+                keyColumn: "id",
+                keyValue: new Guid("22222222-2222-2222-2222-222222222222")
+            );
+            migrationBuilder.DeleteData(
+                schema: "core",
+                table: "accounts",
+                keyColumn: "id",
+                keyValue: new Guid("33333333-3333-3333-3333-333333333333")
+            );
+            migrationBuilder.DeleteData(
+                schema: "core",
+                table: "accounts",
+                keyColumn: "id",
+                keyValue: new Guid("44444444-4444-4444-4444-444444444444")
+            );
+
+            // Categories
+            migrationBuilder.DeleteData(
+                schema: "core",
+                table: "categories",
+                keyColumn: "id",
+                keyValue: new Guid("55555555-5555-5555-5555-555555555555")
+            );
+            migrationBuilder.DeleteData(
+                schema: "core",
+                table: "categories",
+                keyColumn: "id",
+                keyValue: new Guid("66666666-6666-6666-6666-666666666666")
+            );
+            migrationBuilder.DeleteData(
+                schema: "core",
+                table: "categories",
+                keyColumn: "id",
+                keyValue: new Guid("77777777-7777-7777-7777-777777777777")
+            );
+
+            // Family
+            migrationBuilder.DeleteData(
+                schema: "core",
+                table: "families",
+                keyColumn: "id",
+                keyValue: new Guid("11111111-1111-1111-1111-111111111111")
+            );
+        }
+    }
+}
+
+

--- a/BudgetPilot.Web/Models/Category.cs
+++ b/BudgetPilot.Web/Models/Category.cs
@@ -7,6 +7,8 @@ public class Category : FamilyScopedEntity
 {
     public Guid Id { get; set; }
     public string Name { get; set; } = string.Empty;
+    public string? Color { get; set; }
+    public string? Icon { get; set; }
     public Guid? ParentId { get; set; }
     public Category? Parent { get; set; }
 

--- a/BudgetPilot.Web/Models/Family.cs
+++ b/BudgetPilot.Web/Models/Family.cs
@@ -7,6 +7,8 @@ public class Family : AuditableEntity
 {
     public Guid Id { get; set; }
     public string Name { get; set; } = string.Empty;
+    public string Currency { get; set; } = "EUR";
+    public string Culture { get; set; } = "it-IT";
 
     public ICollection<ApplicationUser> Users { get; set; } = new List<ApplicationUser>();
     public ICollection<Account> Accounts { get; set; } = new List<Account>();

--- a/BudgetPilot.Web/Program.cs
+++ b/BudgetPilot.Web/Program.cs
@@ -150,7 +150,7 @@ try
         });
         // Optional: run migrations and seed demo data in Development
         // Note: avoid running during design-time or tooling to prevent host abort
-        if (!EF.IsDesignTime)
+        if (!EF.IsDesignTime && !app.Environment.IsEnvironment("Test"))
         {
             using (var scope = app.Services.CreateScope())
             {

--- a/BudgetPilot.Web/Program.cs
+++ b/BudgetPilot.Web/Program.cs
@@ -34,8 +34,12 @@ try
     // EF Core with PostgreSQL + Snake Case naming convention
     builder.Services.AddDbContext<ApplicationDbContext>(options =>
     {
-        options.UseNpgsql(connectionString)
-               .UseSnakeCaseNamingConvention();
+        options
+            .UseNpgsql(connectionString, npgsql =>
+            {
+                npgsql.MigrationsHistoryTable("__EFMigrationsHistory", "public");
+            })
+            .UseSnakeCaseNamingConvention();
 
         if (builder.Environment.IsDevelopment())
         {
@@ -49,7 +53,12 @@ try
     {
         // Skip service configuration when running migrations
         builder.Services.AddDbContext<ApplicationDbContext>(options =>
-            options.UseNpgsql(connectionString).UseSnakeCaseNamingConvention());
+            options
+                .UseNpgsql(connectionString, npgsql =>
+                {
+                    npgsql.MigrationsHistoryTable("__EFMigrationsHistory", "public");
+                })
+                .UseSnakeCaseNamingConvention());
     }
     else
     {
@@ -139,6 +148,30 @@ try
             ResponseWriter = async (context, report) =>
                 await context.Response.WriteAsync(report.Status.ToString())
         });
+        // Optional: run migrations and seed demo data in Development
+        // Note: avoid running during design-time or tooling to prevent host abort
+        if (!EF.IsDesignTime)
+        {
+            using (var scope = app.Services.CreateScope())
+            {
+                var services = scope.ServiceProvider;
+                var configuration = services.GetRequiredService<Microsoft.Extensions.Configuration.IConfiguration>();
+                var db = services.GetRequiredService<ApplicationDbContext>();
+
+                var applyMigrations = configuration.GetValue<bool>("Database:ApplyMigrations", app.Environment.IsDevelopment());
+                var applySeed = configuration.GetValue<bool>("Database:ApplySeed", app.Environment.IsDevelopment());
+
+                if (applyMigrations)
+                {
+                    db.Database.Migrate();
+                }
+
+                if (applySeed)
+                {
+                    BudgetPilot.Web.Data.Seed.DatabaseSeeder.SeedAsync(db).GetAwaiter().GetResult();
+                }
+            }
+        }
 
         app.Run();
     }

--- a/BudgetPilot.Web/appsettings.Development.json
+++ b/BudgetPilot.Web/appsettings.Development.json
@@ -1,5 +1,9 @@
 {
   "DetailedErrors": true,
+  "Database": {
+    "ApplyMigrations": true,
+    "ApplySeed": true
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Debug",


### PR DESCRIPTION
M0-003: Seed deterministico (GUID fissi, 50/30/20, account demo)
Descrizione
Story: M0-003 - Seed Deterministico
Cosa include:
GUID fissi per entità demo (SeedIds)
Categorie 50/30/20 preconfigurate con colori e icone
Account demo: Conto Principale, Carta, Contanti
Family demo con EUR / it-IT
Seeder configurabile da appsettings (Database.ApplyMigrations/ApplySeed)
Migrazioni EF aggiornate per nuove colonne (Family.Currency/Culture, Category.Color/Icon)
Come verificare:
docker compose up -d
dotnet ef database update
Avvia l’app (Development): seeding attivo da config
Adminer http://localhost:8080 → core.families/core.accounts/core.categories
GUID consistenti su riavvio
Note tecniche:
Storia migration: aggiunte migrazioni SeedMetadata/DemoSeedData
Migrations history table configurata su schema public
Seeding ignora i query filter per tenant in verifica esistenza
Acceptance Criteria:
[x] GUID fissi per entità demo
[x] Categorie 50/30/20
[x] Account demo
[x] Family EUR/it-IT
[x] Colori e icone per categorie
[x] Seed applicato e dati visibili in Adminer
[x] GUID consistenti tra riavvii